### PR TITLE
Return less data for GetAllNames.

### DIFF
--- a/Application/Mappers/NameEntryMapper.cs
+++ b/Application/Mappers/NameEntryMapper.cs
@@ -15,6 +15,16 @@ namespace Application.Mappers
             return names.Select(nameEntry => nameEntry.MapToDto()).ToArray();
         }
 
+        public static NameEntryMiniDto[] MapToDtoCollectionMini(this IEnumerable<NameEntry> names)
+        {
+            return names.Select(nameEntry => new NameEntryMiniDto
+            {
+                Name = nameEntry.Name,
+                Meaning = nameEntry.Meaning,
+                SubmittedBy = nameEntry.CreatedBy
+            }).ToArray();
+        }
+
         public static NameEntry MapToEntity(this NameDto request)
         {
             return new NameEntry

--- a/Application/Services/NameEntryService.cs
+++ b/Application/Services/NameEntryService.cs
@@ -180,7 +180,12 @@ namespace Application.Domain
             return variantCount > 0;
         }
 
-        public async Task<List<NameEntry>> FindBy(State? state, int? pageNumber, int? pageSize, string? submittedBy)
+        public async Task<IEnumerable<NameEntry>> GetAllNames(State? state, string? submittedBy)
+        {
+            return await _nameEntryRepository.GetAllNames(state, submittedBy);
+        }
+
+        public async Task<List<NameEntry>> List(State? state, string? submittedBy, int pageNumber, int pageSize)
         {
             return await _nameEntryRepository.List(pageNumber, pageSize, state, submittedBy);
         }

--- a/Core/Dto/Response/NameEntryDto.cs
+++ b/Core/Dto/Response/NameEntryDto.cs
@@ -18,7 +18,7 @@ namespace Core.Dto.Response
 
         public CommaSeparatedString FamousPeople { get; set; }
         public CommaSeparatedString Media { get; set; }
-        public string SubmittedBy { get; set; }
+        public string? SubmittedBy { get; set; }
 
         public List<EtymologyDto> Etymology { get; set; }
         public List<EmbeddedVideoDto> Videos { get; set; }

--- a/Core/Dto/Response/NameEntryMiniDto.cs
+++ b/Core/Dto/Response/NameEntryMiniDto.cs
@@ -1,9 +1,15 @@
-﻿namespace Core.Dto.Response
+﻿using System.Text.Json.Serialization;
+
+namespace Core.Dto.Response
 {
     public class NameEntryMiniDto
     {
         public string Name { get; set; }
-        public string Meaning { get; set;}
-        public string SubmittedBy { get; set;}
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Meaning { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SubmittedBy { get; set; }
     }
 }

--- a/Core/Entities/NameEntry/NameEntry.cs
+++ b/Core/Entities/NameEntry/NameEntry.cs
@@ -53,6 +53,8 @@ public class NameEntry : BaseEntity, IComparable<NameEntry>
         Variants = new List<string>();
         Morphology = new List<string>();
         Media = new List<string>();
+
+        GeoLocation = new List<GeoLocation>();
     }
 
     public NameEntry(string name, string meaning)

--- a/Core/Repositories/INameEntryRepository.cs
+++ b/Core/Repositories/INameEntryRepository.cs
@@ -46,8 +46,9 @@ namespace Core.Repositories
 
         Task<int> CountWhere(Expression<Func<NameEntry, bool>> filter);
 
-        Task<List<NameEntry>> List(int? pageNumber, int? pageSize, State? state, string? submittedBy);
+        Task<List<NameEntry>> List(int pageNumber, int pageSize, State? state, string? submittedBy);
 
         Task<NamesMetadataDto> GetMetadata();
+        Task<IEnumerable<NameEntry>> GetAllNames(State? state, string? submittedBy);
     }
 }


### PR DESCRIPTION
YNDREV-55

This problem happens because we are loading all the names with all the data in there into the dashboard on each page load. It is too much.

This fix makes sure that only the needed field: "Name" is returned from the API.

Eventually, we would want to eliminate calls to this endpoint entirely and delegate the search function (which uses the response of this call) to the server side.